### PR TITLE
Adding  pySimpleGEIM

### DIFF
--- a/src/python/GEIM/pySimpleGEIM.py
+++ b/src/python/GEIM/pySimpleGEIM.py
@@ -24,7 +24,7 @@ def define_norm_func(func):
     
             
        
-class pyGEIM_offline:
+class GeimFoam_offline:
 
     def __init__(self, snaps_obj, rank, list_observable_fields, norm_type="L2"):
         self.snaps_obj = snaps_obj
@@ -113,7 +113,7 @@ class pyGEIM_offline:
             d_i = np.linalg.solve(mat_A, b)
             self.__J[:, index_snap] = self.matrix_holding_bases[:, :count_basis + 1] @ d_i
     
-class pyGEIM_online:
+class GeimFoam_online:
     def __init__(self, offline_object, snaps_object, rank_upto):
         self.offline_object = offline_object
         self.A = self.offline_object.A[:rank_upto, :rank_upto]

--- a/src/python/GEIM/pySimpleGEIM.py
+++ b/src/python/GEIM/pySimpleGEIM.py
@@ -29,13 +29,13 @@ class pyGEIM_offline:
     def __init__(self, snaps_obj, rank, norm_type="L2"):
         self.snaps_obj = snaps_obj
         self.tot_cells_per_snap = self.snaps_obj.tot_cells_per_snap
-        snaps_array = np.asarray(self.snaps_obj.snapshot_matrix_2D).copy()
+        snaps_array = np.asarray(self.snaps_obj.snapshot_matrix_2D_training).copy()
     
         self.__snaps = snaps_array
         self.rank = rank
         self.list_fields = self.snaps_obj.list_fields_paths
         self.list_field_to_range_cells = self.snaps_obj.list_field_to_range_cells
-        self.Nsnaps = snaps_obj.Nsnapshots
+        self.Nsnaps = snaps_obj.Nsnapshots_training
         self.Nfields = len(self.list_fields)
         self.dict_centroids_and_volumes_by_region = self.snaps_obj.dict_centroids_and_volumes_by_region
         self.norm_type = norm_type
@@ -49,7 +49,7 @@ class pyGEIM_offline:
         self.indices_sensor_snaps = np.zeros(self.rank, dtype=int)
         self.matrix_holding_bases = np.zeros((self.tot_cells_per_snap, self.rank))
         self.indices_position_sensors = np.zeros((self.rank), dtype=int)
-        self.__array_indices_maximizing_position = np.zeros((self.rank), dtype=int)
+        self.array_indices_maximizing_position = np.zeros((self.rank), dtype=int)
         self.scaling_factor = np.zeros((self.rank), dtype=float)
             
     def run_algorithm(self):
@@ -83,17 +83,17 @@ class pyGEIM_offline:
         self.matrix_holding_bases[:, count_basis] = copy.deepcopy(self.__residual_snaps[:, basis_snap_index])
         (index_start, index_end) = self.list_field_to_range_cells[sensor_field_index]
         index_maximizing_position = np.argmax(np.abs(self.matrix_holding_bases[index_start : index_end + 1, count_basis]))
-        self.__array_indices_maximizing_position[count_basis] = int(index_maximizing_position + index_start)
+        self.array_indices_maximizing_position[count_basis] = int(index_maximizing_position + index_start)
         self.indices_position_sensors[count_basis] = index_maximizing_position
         self.indices_sensor_fields[count_basis] = sensor_field_index
         self.indices_sensor_snaps[count_basis] = basis_snap_index
-        self.scaling_factor[count_basis] = self.matrix_holding_bases[self.__array_indices_maximizing_position[count_basis], count_basis]
+        self.scaling_factor[count_basis] = self.matrix_holding_bases[self.array_indices_maximizing_position[count_basis], count_basis]
 
     def __build_A(self, count_basis):
         for i in range(count_basis + 1):
                 for j in range(count_basis + 1):
                     if i == count_basis or j == count_basis:
-                        self.A[i, j] = self.matrix_holding_bases[self.__array_indices_maximizing_position[i], j] / self.scaling_factor[i]
+                        self.A[i, j] = self.matrix_holding_bases[self.array_indices_maximizing_position[i], j] / self.scaling_factor[i]
 
     def __coord_maximizing_snap_finder(self, norms):
         coord_max = np.unravel_index(np.argmax(norms), norms.shape)
@@ -102,14 +102,30 @@ class pyGEIM_offline:
     def __reconstruct_training_space(self, count_basis):
         mat_A = self.A[:count_basis + 1, :count_basis + 1]
         for index_snap in range(self.Nsnaps):
-            b = np.asarray(self.__snaps[self.__array_indices_maximizing_position[:count_basis + 1], index_snap]) / self.scaling_factor[:count_basis + 1]
+            b = np.asarray(self.__snaps[self.array_indices_maximizing_position[:count_basis + 1], index_snap]) / self.scaling_factor[:count_basis + 1]
             d_i = np.linalg.solve(mat_A, b)
             self.__J[:, index_snap] = self.matrix_holding_bases[:, :count_basis + 1] @ d_i
     
 class pyGEIM_online:
-    def __init__(self, offline_object, snaps_object):
+    def __init__(self, offline_object, snaps_object, rank_upto):
         self.offline_object = offline_object
+        self.A = self.offline_object.A
+        self.array_indices_maximizing_position = self.offline_object.array_indices_maximizing_position
+        self.rank_upto = rank_upto
+        self.scaling_factor = self.offline_object.scaling_factor
+        self.matrix_holding_bases = self.offline_object.matrix_holding_bases
         self.snaps_object = snaps_object
+        self.snapshot_testing = self.snaps_object.snapshot_matrix_2D_testing
+        self.Nsnaps = self.snapshot_testing.shape[1]
+        self.J = np.zeros(self.snapshot_testing.shape)
+        self.reconstruct_test_space()
+        
+    def reconstruct_test_space(self):
+        for index_snap in range(self.Nsnaps):
+            b = np.asarray(self.snapshot_testing[self.array_indices_maximizing_position[:self.rank_upto], index_snap]) / self.scaling_factor[:self.rank_upto]
+            d_i = np.linalg.solve(self.A, b)
+            self.J[:, index_snap] = self.matrix_holding_bases[:, :self.rank_upto] @ d_i
+    
 
 
 # Initialise the snapshot manager:

--- a/src/python/GEIM/pySimpleGEIM.py
+++ b/src/python/GEIM/pySimpleGEIM.py
@@ -1,6 +1,6 @@
-## MOST OF THE DEPENDENCIES ARE MISSING FOR NOW
-import numpy as np
 import copy
+import numpy as np
+
 def split_on_slash(input_string):
         if '/' in input_string:
             before, after = input_string.split('/', 1)
@@ -104,7 +104,7 @@ class pyGEIM_offline:
     def __coord_maximizing_snap_finder(self, norms):
         index_obs_field, index_snap = np.unravel_index(np.argmax(norms), norms.shape)
         index_field = self.list_indices_observable_fields[index_obs_field]
-        return (index_obs_field, index_snap)
+        return (index_field, index_snap)
   
     def __reconstruct_training_space(self, count_basis):
         mat_A = self.A[:count_basis + 1, :count_basis + 1]
@@ -116,7 +116,7 @@ class pyGEIM_offline:
 class pyGEIM_online:
     def __init__(self, offline_object, snaps_object, rank_upto):
         self.offline_object = offline_object
-        self.A = self.offline_object.A
+        self.A = self.offline_object.A[:rank_upto, :rank_upto]
         self.array_indices_maximizing_position = self.offline_object.array_indices_maximizing_position
         self.rank_upto = rank_upto
         self.scaling_factor = self.offline_object.scaling_factor
@@ -133,50 +133,3 @@ class pyGEIM_online:
             d_i = np.linalg.solve(self.A, b)
             self.J[:, index_snap] = self.matrix_holding_bases[:, :self.rank_upto] @ d_i
     
-
-
-# Initialise the snapshot manager:
-project_dir = "../DAFOAM/project_check_geim_foam"
-source_dir = "../DAFOAM/examples/td_2D_MSFR/pumpPowerVariation/case_space"
-sm_obj = sm.Snapshot_manager(source_dir, project_dir)  
-sm_obj.set_environment()
-
-# Define list of fields of interest and list of observable fields, identify the index of the observable fields within the list of fields of interest:
-all_fields = ['fluidRegion/p','fluidRegion/T','neutroRegion/TFuel','neutroRegion/flux0','neutroRegion/flux1','neutroRegion/flux2','neutroRegion/flux3','neutroRegion/flux4','neutroRegion/flux5','neutroRegion/prec0','neutroRegion/prec1','neutroRegion/prec2','neutroRegion/prec3','neutroRegion/prec4','neutroRegion/prec5','neutroRegion/powerDensity']
-obs_fields = ['fluidRegion/p', 'fluidRegion/T', 'neutroRegion/flux5']
-obs_idx = [all_fields.index(field) for field in obs_fields]
-
-# Assemble training array (3D array with snapshots, fields and locations):
-asd = Snapshot_matrix_builder(sm_obj, all_fields)
-training_array = np.array(asd.snapshot_matrix_3D)
-
-# Identify the field with the maximum absolute value in the training matrix for the specified observation fields:
-snp_idx, fld_idx, loc_idx = np.unravel_index(np.argmax(np.abs(training_array[:, obs_idx, :])), training_array[:, obs_idx, :].shape)
-
-# Initialise sensors, scaling factors and basis:
-list_magic_fields = [obs_idx[fld_idx]]
-list_magic_points = [loc_idx]
-list_scaling_factors = [training_array[snp_idx, obs_idx[fld_idx], loc_idx]]
-basis = training_array[snp_idx:snp_idx+1, :, :]
-
-# Determine number of pasis to be computed and enter GEIM main loop:
-N_basis = 28
-for ii in range(1, N_basis):
-
-    #  Compute combination coefficients for the current basis and training matrix:
-    training_measurements = np.array([training_array[:, list_magic_fields[rr], list_magic_points[rr]] / list_scaling_factors[rr] for rr in range(ii)])
-    basis_measurements = np.array([[basis[rr, list_magic_fields[kk], list_magic_points[kk]] / list_scaling_factors[kk] for rr in range(ii)] for kk in range(ii)])
-    linear_combination_coefficients = np.linalg.solve(basis_measurements, training_measurements)
-
-    # Construct the interpolation residuals:
-    residual = training_array - np.einsum('ir,ijk->rjk', linear_combination_coefficients, basis)
-
-    # Identify maximum of the absolute value of the observable residuals:
-    snp_idx, fld_idx, loc_idx = np.unravel_index(np.argmax(np.abs(residual[:, obs_idx, :])), residual[:, obs_idx, :].shape)
-
-    # Append new sensor, scaling factor and basis:
-    list_magic_fields.append(obs_idx[fld_idx])
-    list_magic_points.append(loc_idx)
-    list_scaling_factors.append(residual[snp_idx, obs_idx[fld_idx], loc_idx])
-    basis = np.concatenate((basis, residual[snp_idx:snp_idx+1, :, :]), axis=0)
-

--- a/src/python/GEIM/pySimpleGEIM.py
+++ b/src/python/GEIM/pySimpleGEIM.py
@@ -2,31 +2,55 @@ import copy
 import numpy as np
 
 def split_on_slash(input_string):
-        if '/' in input_string:
-            before, after = input_string.split('/', 1)
-        else:
-            before = ''
-            after = input_string
-        return before, after
+    """Split a string on the first '/' character.
+    
+    Returns:
+        tuple: (before_slash, after_slash) where before_slash is empty if no '/' found
+    """
+    if '/' in input_string:
+        before, after = input_string.split('/', 1)
+    else:
+        before = ''
+        after = input_string
+    return before, after
 
 
-def define_norm_func(func):
-    def definition(self, field_values, region):
-        if self.norm_type == "L2":
-            volumes = self.dict_centroids_and_volumes_by_region[region][1]
+def determine_norm_func(norm_type):
+    """Return a norm function based on the specified norm type.
+    
+    Args:
+        norm_type (str): Type of norm ("L2" or "Linf")
+        
+    Returns:
+        function: Norm calculation function
+    """
+    if norm_type == "L2":
+        def definition(instance, field_values, region):
+            volumes = instance.dict_centroids_and_volumes_by_region[region][1]
             return np.sqrt(np.sum(field_values ** 2 * volumes))
-        elif self.norm_type == "Linf":
+    elif norm_type == "Linf":
+        def definition(instance, field_values, region):
             return np.max(np.abs(field_values))
-        else:
-            raise ValueError(f"Unsupported norm type: {self.norm_type}")
-    
+    else:
+        raise ValueError(f"Unsupported norm type: {norm_type}")
     return definition
-    
             
        
-class GeimFoam_offline:
+class pyGEIM_offline:
+    """Offline phase of the Generalized Empirical Interpolation Method (GEIM).
+    
+    Determine sensor locations and Construct basis functions from training snapshots.
+    """
 
     def __init__(self, snaps_obj, rank, list_observable_fields, norm_type="L2"):
+        """Initialize the offline GEIM algorithm.
+        
+        Args:
+            snaps_obj: Snapshot matrix builder object containing training data
+            rank (int): Number of basis functions to construct
+            list_observable_fields (list): List of observable field names
+            norm_type (str): Type of norm to use ("L2" or "Linf")
+        """
         self.snaps_obj = snaps_obj
         self.tot_cells_per_snap = self.snaps_obj.tot_cells_per_snap
         snaps_array = np.asarray(self.snaps_obj.snapshot_matrix_2D_training).copy()
@@ -45,6 +69,8 @@ class GeimFoam_offline:
 
         self.dict_centroids_and_volumes_by_region = self.snaps_obj.dict_centroids_and_volumes_by_region
         self.norm_type = norm_type
+        #define the norm detrmining method based on the norm type
+        self.__determine_norm_field = determine_norm_func(norm_type=self.norm_type)
         #approximation
         self.__J = np.zeros((self.tot_cells_per_snap, self.Nsnaps))
         self.norm_snaps = np.zeros((self.Nobs, self.Nsnaps))
@@ -59,18 +85,16 @@ class GeimFoam_offline:
         self.scaling_factor = np.zeros((self.rank), dtype=float)
             
     def run_algorithm(self):
+        """Execute the offline GEIM algorithm to construct basis functions and sensor locations."""
         for count_basis in range(self.rank):
             self.__residual_snaps = self.__snaps - self.__J
             self.__generate_norm_snaps(residual=False if count_basis==0 else True)
             self.__keep_the_book(count_basis=count_basis, norm_resid_snaps=self.norm_snaps if count_basis==0 else self.normalized_norm_residual_snaps)
             self.__build_A(count_basis=count_basis)
             self.__reconstruct_training_space(count_basis=count_basis)
-    
-    @define_norm_func 
-    def __determine_norm_field(self, field_values, region):
-        pass
 
     def __generate_norm_snaps(self, residual=True):
+        """Compute norms of snapshot fields or residuals."""
         for ii, field in enumerate(self.list_observable_fields):
             region, field_name = split_on_slash(field)
             index_field = self.list_indices_observable_fields[ii]
@@ -78,12 +102,13 @@ class GeimFoam_offline:
             for jj in range(self.Nsnaps):
                 if residual is False:
                     field_values = self.__snaps[index_start : index_end + 1, jj]
-                    self.norm_snaps[ii, jj] = self.__determine_norm_field(field_values=field_values, region=region)
+                    self.norm_snaps[ii, jj] = self.__determine_norm_field(self, field_values=field_values, region=region)
                 else:
                     field_values = self.__residual_snaps[index_start : index_end + 1, jj]
-                    self.normalized_norm_residual_snaps[ii, jj] = self.__determine_norm_field(field_values=field_values, region=region) / self.norm_snaps[ii, jj]
+                    self.normalized_norm_residual_snaps[ii, jj] = self.__determine_norm_field(self, field_values=field_values, region=region) / self.norm_snaps[ii, jj]
 
     def __keep_the_book(self, count_basis, norm_resid_snaps):
+        """Store basis function and sensor information for current iteration."""
         (sensor_field_index, basis_snap_index) = self.__coord_maximizing_snap_finder(norm_resid_snaps)
         self.matrix_holding_bases[:, count_basis] = copy.deepcopy(self.__snaps[:, basis_snap_index])
         self.matrix_holding_bases[:, count_basis] = copy.deepcopy(self.__residual_snaps[:, basis_snap_index])
@@ -96,25 +121,37 @@ class GeimFoam_offline:
         self.scaling_factor[count_basis] = self.matrix_holding_bases[self.array_indices_maximizing_position[count_basis], count_basis]
 
     def __build_A(self, count_basis):
+        """Build the System matrix A."""
         for i in range(count_basis + 1):
                 for j in range(count_basis + 1):
                     if i == count_basis or j == count_basis:
                         self.A[i, j] = self.matrix_holding_bases[self.array_indices_maximizing_position[i], j] / self.scaling_factor[i]
 
     def __coord_maximizing_snap_finder(self, norms):
+        """Find the field and snapshot indices that maximize the norm."""
         index_obs_field, index_snap = np.unravel_index(np.argmax(norms), norms.shape)
         index_field = self.list_indices_observable_fields[index_obs_field]
         return (index_field, index_snap)
   
     def __reconstruct_training_space(self, count_basis):
+        """Reconstruct the training snapshots using current basis functions."""
         mat_A = self.A[:count_basis + 1, :count_basis + 1]
         for index_snap in range(self.Nsnaps):
             b = np.asarray(self.__snaps[self.array_indices_maximizing_position[:count_basis + 1], index_snap]) / self.scaling_factor[:count_basis + 1]
             d_i = np.linalg.solve(mat_A, b)
             self.__J[:, index_snap] = self.matrix_holding_bases[:, :count_basis + 1] @ d_i
     
-class GeimFoam_online:
+class pyGEIM_online:
+    """Online phase of GEIM for reconstructing test snapshots using precomputed basis."""
+    
     def __init__(self, offline_object, snaps_object, rank_upto):
+        """Initialize the online GEIM reconstruction.
+        
+        Args:
+            offline_object: Completed offline GEIM object
+            snaps_object: Snapshot Matrix Builder object containing test data
+            rank_upto (int): Number of basis functions to use for reconstruction
+        """
         self.offline_object = offline_object
         self.A = self.offline_object.A[:rank_upto, :rank_upto]
         self.array_indices_maximizing_position = self.offline_object.array_indices_maximizing_position
@@ -128,8 +165,8 @@ class GeimFoam_online:
         self.reconstruct_test_space()
         
     def reconstruct_test_space(self):
+        """Reconstruct all test snapshots using the precomputed GEIM basis."""
         for index_snap in range(self.Nsnaps):
             b = np.asarray(self.snapshot_testing[self.array_indices_maximizing_position[:self.rank_upto], index_snap]) / self.scaling_factor[:self.rank_upto]
             d_i = np.linalg.solve(self.A, b)
             self.J[:, index_snap] = self.matrix_holding_bases[:, :self.rank_upto] @ d_i
-    

--- a/src/python/GEIM/pySimpleGEIM.py
+++ b/src/python/GEIM/pySimpleGEIM.py
@@ -96,7 +96,7 @@ class pyGEIM_offline:
     def __generate_norm_snaps(self, residual=True):
         """Compute norms of snapshot fields or residuals."""
         for ii, field in enumerate(self.list_observable_fields):
-            region, field_name = split_on_slash(field)
+            region, _ = split_on_slash(field)
             index_field = self.list_indices_observable_fields[ii]
             (index_start, index_end) = self.list_field_to_range_cells[index_field]
             for jj in range(self.Nsnaps):
@@ -162,9 +162,9 @@ class pyGEIM_online:
         self.snapshot_testing = self.snaps_object.snapshot_matrix_2D_testing
         self.Nsnaps = self.snapshot_testing.shape[1]
         self.J = np.zeros(self.snapshot_testing.shape)
-        self.reconstruct_test_space()
+        self.__reconstruct_test_space()
         
-    def reconstruct_test_space(self):
+    def __reconstruct_test_space(self):
         """Reconstruct all test snapshots using the precomputed GEIM basis."""
         for index_snap in range(self.Nsnaps):
             b = np.asarray(self.snapshot_testing[self.array_indices_maximizing_position[:self.rank_upto], index_snap]) / self.scaling_factor[:self.rank_upto]


### PR DESCRIPTION


This pull request adds the `pySimpleGEIM.py` module, which can run `GEIM à la Ragusa` on the snapshot matrix obtained from a `snapshot_matrix_builder` object (see PR #20).

**Location:** `src/python/GEIM/`

The module contains two classes that can be imported as follows:

```python
from pySimpleGEIM import pyGEIM_offline, pyGEIM_online
```
*Offline Phase*
An object of the offline class can be instantiated as:
```python
geim_offline = pyGEIM_offline(snaps_obj=sm_builder_obj, rank=40, list_observable_fields=obs_fields)
```
After instantiation, run the algorithm:
```python
geim_offline.run_algorithm()
```
Once the algorithm completes, the object contains the basis functions, sensor locations, and system matrix.
*Online Phase*
The online class can then be instantiated (requires a completed offline object):
```python
geim_online = pyGEIM_online(offline_object=geim_offline, snaps_object=sm_builder_obj)
```